### PR TITLE
Update __init__.py

### DIFF
--- a/livetest3/__init__.py
+++ b/livetest3/__init__.py
@@ -70,7 +70,7 @@ class TestApp(webtest.TestApp):
 
     def _do_httplib_request(self, req):
         "Convert WebOb Request to httplib request."
-        headers = dict((name, val) for name, val in req.headers.iteritems()
+        headers = dict((name, val) for name, val in req.headers.items()
                        if name != 'Host')
         if req.scheme not in self.conn:
             self._load_conn(req.scheme)


### PR DESCRIPTION
In Python 3, dict.iteritems was renamed to dict.items. You should do this renaming in your code as well. In Python 2, dict.items works too, though this will give back a list of items, whereas dict.iteritems in Python 2 (and dict.items in Python 3) gives back a generator, enabling low-memory looping over the items.